### PR TITLE
Logging Improvements + Add stop fn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,17 @@
-{:deps  {clj-http  {:mvn/version "3.10.0"}
-         stylefruits/gniazdo  {:mvn/version  "1.1.2"}
-         org.clojure/core.memoize  {:mvn/version "0.8.2"}
-         cheshire {:mvn/version "5.9.0"}}
- :paths ["src" "classes" "impl"]
- :aliases {:jar  {:extra-deps  {seancorfield/depstar  {:mvn/version  "RELEASE"}}
-                  :main-opts  ["-m"  "hf.depstar.jar"]}
-           :install  {:extra-deps  {deps-deploy  {:mvn/version  "RELEASE"}}
-                      :main-opts  ["-m"  "deps-deploy.deps-deploy"  "install"]}
-           :deploy {:extra-deps  {slipset/deps-deploy  {:mvn/version  "RELEASE"}}
-                    :exec-fn deps-deploy.deps-deploy/deploy
-                    :exec-args  {:installer :remote
-                                 :sign-releases? false 
-                                 :artifact  "discord-bot.jar"}} 
-           :nrepl  {:extra-deps  {nrepl  {:mvn/version  "RELEASE"}}
-                    :main-opts  ["-m"  "nrepl.cmdline"]}}}
+{:deps    {cheshire/cheshire        {:mvn/version "5.9.0"}
+           clj-http/clj-http        {:mvn/version "3.10.0"}
+           org.clojure/core.memoize {:mvn/version "0.8.2"}
+           org.clojure/tools.logging {:mvn/version "1.1.0"}
+           stylefruits/gniazdo      {:mvn/version "1.1.2"}}
+ :paths   ["src" "classes" "impl"]
+ :aliases {:jar     {:extra-deps {seancorfield/depstar {:mvn/version "RELEASE"}}
+                     :main-opts  ["-m"  "hf.depstar.jar"]}
+           :install {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+                     :main-opts  ["-m"  "deps-deploy.deps-deploy"  "install"]}
+           :deploy  {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+                     :exec-fn    deps-deploy.deps-deploy/deploy
+                     :exec-args  {:installer      :remote
+                                  :sign-releases? false
+                                  :artifact       "discord-bot.jar"}}
+           :nrepl   {:extra-deps {nrepl {:mvn/version "RELEASE"}}
+                     :main-opts  ["-m"  "nrepl.cmdline"]}}}

--- a/src/discord_bot/clients/discord/http.clj
+++ b/src/discord_bot/clients/discord/http.clj
@@ -1,12 +1,12 @@
 (ns discord-bot.clients.discord.http
-  (:require [clj-http.client :as http]
-            [cheshire.core :as json]
-            [discord-bot.config :refer [get-config] :as config]))
+  (:require [cheshire.core] ;; Cheshire needs to be on the classpath for clj-http auto coercion
+            [clj-http.client :as http]
+            [discord-bot.config :refer [get-config]]))
 
 (defn mk-headers
   []
   {"Authorization" (str "Bot " (get-config [:token]))
-   "User-Agent" (str (get-config [:project-name]) " " (get-config [:project-version]))})
+   "User-Agent"    (str (get-config [:project-name]) " " (get-config [:project-version]))})
 
 (defn parse-channels
   [channels]
@@ -24,10 +24,10 @@
 
 (defn send-channel-message
   [channel-id params]
-  (-> (http/post (str (get-config [:url]) "channels/" channel-id "/messages")
-                 {:headers (mk-headers)
-                  :content-type :json
-                  :form-params params})))
+  (http/post (str (get-config [:url]) "channels/" channel-id "/messages")
+             {:headers      (mk-headers)
+              :content-type :json
+              :form-params  params}))
 
 (defn get-channels
   [server-id]

--- a/src/discord_bot/clients/discord/ws.clj
+++ b/src/discord_bot/clients/discord/ws.clj
@@ -214,6 +214,7 @@
                                     :on-receive #(handle-message % opts))))
 (defn stop
   []
+  (reset! intentionally-disconnected true)
   (ws/close @ws-connection))
 
 

--- a/src/discord_bot/clients/discord/ws.clj
+++ b/src/discord_bot/clients/discord/ws.clj
@@ -215,7 +215,7 @@
 (defn stop
   []
   (reset! intentionally-disconnected true)
-  (ws/close @ws-connection))
+  (close-connection))
 
 
 (comment

--- a/src/discord_bot/clients/discord/ws.clj
+++ b/src/discord_bot/clients/discord/ws.clj
@@ -212,6 +212,10 @@
                                                   (initialize opts true))) ; this is where we previously tried to resume depending on the status code, but it doesn't work and gave up
                                     :on-error on-error
                                     :on-receive #(handle-message % opts))))
+(defn stop
+  []
+  (ws/close @ws-connection))
+
 
 (comment
   (ws/close @ws-connection)

--- a/src/discord_bot/config.clj
+++ b/src/discord_bot/config.clj
@@ -1,12 +1,13 @@
 (ns discord-bot.config
-  (:require [clojure.core.memoize :as memo]))
+  (:require [clojure.core.memoize :as memo]
+            [clojure.edn :as edn]))
 
 (defonce url "https://discordapp.com/api/")
 (defonce ws-url "wss://gateway.discord.gg/?v=6&encoding=json")
 
 (defn bot-config*
   []
-  (clojure.edn/read-string (slurp "./bot.edn")))
+  (edn/read-string (slurp "./bot.edn")))
 
 (def bot-config (memo/ttl bot-config* :ttl/threshold (* 10 1000)))
 

--- a/src/discord_bot/core.clj
+++ b/src/discord_bot/core.clj
@@ -4,6 +4,7 @@
 
 ; WEBSOCKETS AND INITIALIZATION
 (def init ws/initialize)
+(def stop ws/stop)
 
 ; UTILITY
 (defn get-presences

--- a/src/discord_bot/core.clj
+++ b/src/discord_bot/core.clj
@@ -15,7 +15,7 @@
 (defn server-state
   []
   ws/server-state)
-;(get-presences)
+
 ; CHANNELS
 (def get-channels http/get-channels)
 (def send-channel-message http/send-channel-message)


### PR DESCRIPTION
Using clojure.tools.logging allows consumers to integrate with their logging provider of choice (e.g. timbre).

Additionally, I exposed some functionality for intentionally stopping bots.